### PR TITLE
Set default country viewport after country filter change

### DIFF
--- a/src/components/countries-dropdown/component.jsx
+++ b/src/components/countries-dropdown/component.jsx
@@ -6,9 +6,9 @@ import cx from 'classnames';
 import styles from './styles.module.scss';
 
 const CountriesDropdown = () => {
-  const match = useRouteMatch('/:iso');
+  const match = useRouteMatch('/:iso/:page');
 
-  const { iso } = (match && match.params) || '';
+  const { iso, page } = (match && match.params) || '';
   const [countrySelectorOpen, setCountrySelector] = useState(false);
   const activeCountry = COUNTRIES.find(country => country.iso === iso);
 
@@ -31,7 +31,7 @@ const CountriesDropdown = () => {
             <Link
               key={country.iso}
               className={styles.imageLink}
-              to={`/${country.iso}/species/`}
+              to={`/${country.iso}/${page}/`}
               onClick={toggleCountryDropdown}
             >
               <img className={styles['shape__no-hover']} src={country.svg} alt={country.name} />

--- a/src/constants.js
+++ b/src/constants.js
@@ -41,3 +41,11 @@ export const COUNTRIES = [
     svgActive: tanzaniaActive
   }
 ];
+
+export const COUNTRIES_DEFAULT_VIEWPORTS = {
+  CAN: { zoom: 2, latitude: 56.1351095, longitude: -106.3460756 },
+  SWE: { zoom: 4, latitude: 62.295911, longitude: 17.861953 },
+  IDN: { zoom: 3, latitude: -4.341701, longitude: 122.389996 },
+  PER: { zoom: 4, latitude: -10.471441, longitude: -75.135125 },
+  TZA: { zoom: 5, latitude: -5.790175, longitude: 36.718777 }
+};

--- a/src/pages/bioclimatic/component.jsx
+++ b/src/pages/bioclimatic/component.jsx
@@ -15,13 +15,12 @@ import Timeline from 'components/map/controls/timeline';
 import layers from 'layers.json';
 
 function BioClimaticPage(props) {
-  const { getConfig, filters, data, timelineData } = props;
+  const { getConfig, filters, data, timelineData, viewport, setViewport } = props;
   const { scenario, parsedScenarios } = filters;
 
   const parsedScenario = parsedScenarios && parsedScenarios.find(s => s.value === scenario);
   const biovarsData = groupBy(data.countryBiovarDistributions, 'biovar.key');
   const [activeLayers, setActiveLayers] = useState(layers.map(l => ({ ...l, active: true })));
-  const [viewport, setViewport] = useState({ zoom: 4, latitude: 40, longitude: -5 });
 
   return (
     <div className="c-bioclimatic l-page">

--- a/src/pages/bioclimatic/index.js
+++ b/src/pages/bioclimatic/index.js
@@ -30,7 +30,7 @@ const Container = () => {
   // graphql
   const { data } = useScenariosPerCountry(country);
 
-  useEffect(() => setViewport(COUNTRIES_DEFAULT_VIEWPORTS[country])[country], [country]);
+  useEffect(() => setViewport(COUNTRIES_DEFAULT_VIEWPORTS[country]), [country]);
 
   // parsing
   const scenarios = data && data.scenarios && data.scenarios.filter(s => s.key !== 'current');

--- a/src/pages/bioclimatic/index.js
+++ b/src/pages/bioclimatic/index.js
@@ -1,6 +1,7 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useEffect, useState } from 'react';
 import { useRouteMatch, useLocation, useHistory } from 'react-router-dom';
 import { useQueryParams, setQueryParams } from 'url.js';
+import { COUNTRIES_DEFAULT_VIEWPORTS } from 'constants.js';
 import { useScenariosPerCountry } from 'graphql/queries';
 import { Query } from 'urql';
 import { Label } from 'recharts';
@@ -24,9 +25,12 @@ const Container = () => {
   const { country } = (match && match.params) || {};
   const currentQueryParams = useQueryParams();
   const { startYear, endYear, scenario } = currentQueryParams;
+  const [viewport, setViewport] = useState({ zoom: 4, latitude: 40, longitude: -5 });
 
   // graphql
   const { data } = useScenariosPerCountry(country);
+
+  useEffect(() => setViewport(COUNTRIES_DEFAULT_VIEWPORTS[country])[country], [country]);
 
   // parsing
   const scenarios = data && data.scenarios && data.scenarios.filter(s => s.key !== 'current');
@@ -186,6 +190,8 @@ const Container = () => {
               filters={filters}
               getConfig={getChartConfig}
               timelineData={timelineData}
+              viewport={viewport}
+              setViewport={setViewport}
             />
           )}
       </Query>

--- a/src/pages/distribution/index.js
+++ b/src/pages/distribution/index.js
@@ -1,9 +1,10 @@
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { useLocation, useHistory } from 'react-router-dom';
+import { uniqBy } from 'lodash';
 import { useScenariosPerCountry } from 'graphql/queries';
 import { useQueryParams, setQueryParams } from 'url.js';
-import { uniqBy } from 'lodash';
+import { COUNTRIES_DEFAULT_VIEWPORTS } from 'constants.js';
 
 import Component from './component';
 
@@ -12,6 +13,8 @@ const DistributionPage = props => {
 
   const { match } = props;
   const { iso } = (match && match.params) || {};
+
+  useEffect(() => setViewport(COUNTRIES_DEFAULT_VIEWPORTS[iso]), [iso]);
 
   const location = useLocation();
   const history = useHistory();


### PR DESCRIPTION
This small PR adds a feature which centers the viewport of the map to the selected country, works both on `Map distribution` and `Bioclimatic variables` pages:
![27kbh-w1izv](https://user-images.githubusercontent.com/15097138/68389509-0376f200-015b-11ea-832e-6baf14193914.gif)