### PR TITLE
Feature/observed features

### DIFF
--- a/src/components/map/controls/timeline/styles.module.scss
+++ b/src/components/map/controls/timeline/styles.module.scss
@@ -34,6 +34,7 @@ $timeline-size: 45px;
   border-left: 1px solid $color-gray-3;
   font-size: $font-size-small;
   padding: 0 12px;
+  text-transform: uppercase;
 }
 
 .activeTab {

--- a/src/components/species-list/component.jsx
+++ b/src/components/species-list/component.jsx
@@ -1,22 +1,31 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
+
 import styles from './styles.module.scss';
 
 function SpeciesList({ species, country, page, activeSpecies }) {
+  const currentQueryParams = useLocation();
+
   return (
     <div className={styles.container}>
       <div className={styles.speciesActive}>{activeSpecies.scientificName}</div>
       <ul className={styles.list}>
         {species &&
           country &&
-          species.map(s => (
-            <li key={s.id}>
-              <Link to={`/${country.iso}/${page}/${s.id}`} className={styles.listItem}>
-                <p>{s.scientificName}</p>
-              </Link>
-            </li>
-          ))}
+          species.map(s => {
+            const URL = {
+              pathname: `/${country.iso}/${page}/${s.id}`,
+              search: currentQueryParams ? currentQueryParams.search : ''
+            };
+            return (
+              <li key={s.id}>
+                <Link to={URL} className={styles.listItem}>
+                  <p>{s.scientificName}</p>
+                </Link>
+              </li>
+            );
+          })}
       </ul>
     </div>
   );

--- a/src/components/species-list/component.jsx
+++ b/src/components/species-list/component.jsx
@@ -14,6 +14,7 @@ function SpeciesList({ species, country, page, activeSpecies }) {
         {species &&
           country &&
           species.map(s => {
+            // search preserves params when clicking on another species. Without this, we're losing information about selected layers on the map
             const URL = {
               pathname: `/${country.iso}/${page}/${s.id}`,
               search: currentQueryParams ? currentQueryParams.search : ''

--- a/src/layers/speciesOccurence.js
+++ b/src/layers/speciesOccurence.js
@@ -28,17 +28,10 @@ export default (iso, species, opacity = 1) => {
           {
             paint: {
               'circle-color': SPECIES_RAMP_COLORS[2],
-              'circle-stroke-color': SPECIES_RAMP_COLORS[1],
-              'circle-stroke-width': 1,
-              'circle-opacity': opacity
-              // 'circle-radius': {
-              //   type: 'interval',
-              //   stops: [
-              //       [0, 2],
-              //       [100, 30],
-              //       [750, 40]
-              //   ]
-              // },
+              'circle-opacity': opacity,
+              'circle-radius': {
+                stops: [[12, 2], [22, 180]]
+              }
             },
             'source-layer': 'layer0',
             type: 'circle'

--- a/src/layers/speciesOccurence.js
+++ b/src/layers/speciesOccurence.js
@@ -1,0 +1,67 @@
+import { SPECIES_RAMP_COLORS } from 'constants.js';
+
+// vector carto layer for species occurence data
+export default (iso, species, opacity = 1) => {
+  return {
+    id: `${iso}${species}`,
+    name: 'Species occurence carto layer',
+    sqlParams: {
+      where: {
+        iso3: iso,
+        species
+      }
+    },
+    layerConfig: {
+      account: 'simbiotica',
+      body: {
+        layers: [
+          {
+            options: {
+              sql: `SELECT * FROM all_spp_occurence {{where}}`
+            },
+            type: 'cartodb'
+          }
+        ],
+        maxzoom: 3,
+        minzoom: 2,
+        vectorLayers: [
+          {
+            paint: {
+              'circle-color': SPECIES_RAMP_COLORS[2],
+              'circle-stroke-color': SPECIES_RAMP_COLORS[1],
+              'circle-stroke-width': 1,
+              'circle-opacity': opacity
+              // 'circle-radius': {
+              //   type: 'interval',
+              //   stops: [
+              //       [0, 2],
+              //       [100, 30],
+              //       [750, 40]
+              //   ]
+              // },
+            },
+            'source-layer': 'layer0',
+            type: 'circle'
+          }
+        ]
+      },
+      params_config: [],
+      sql_config: [
+        {
+          key: 'where',
+          key_params: [
+            {
+              key: 'iso3',
+              required: true
+            },
+            {
+              key: 'species',
+              required: true
+            }
+          ]
+        }
+      ]
+    },
+    provider: 'cartodb'
+  };
+};

--- a/src/pages/distribution/component.jsx
+++ b/src/pages/distribution/component.jsx
@@ -21,7 +21,10 @@ const DistributionPageComponent = ({
   setFutureScenario,
   futureScenariosData,
   futureScenariosLayers,
+  currentScenariosData,
   currentScenariosLayers,
+  activeCurrentScenario,
+  setCurrentScenario,
   yearIndex,
   setYearIndex,
   setOpacity
@@ -63,7 +66,13 @@ const DistributionPageComponent = ({
         yearIndex={yearIndex}
         handleOnChange={index => setYearIndex(() => index)}
       />
-      <Timeline title="Current distribution" data={{}} hideTimeline />
+      <Timeline
+        title="Current distribution"
+        data={currentScenariosData}
+        hideTimeline
+        activeTab={activeCurrentScenario}
+        setActiveTab={setCurrentScenario}
+      />
       <div className={styles.navigationBar}>
         <Zoom viewport={viewport} setViewport={setViewport} />
         <LayerToggle theme={styles.layerToggle} />
@@ -93,6 +102,9 @@ DistributionPageComponent.propTypes = {
   setFutureScenario: PropTypes.func,
   futureScenariosData: PropTypes.object,
   futureScenariosLayers: PropTypes.array,
+  activeCurrentScenario: PropTypes.string,
+  setCurrentScenario: PropTypes.func,
+  currentScenariosData: PropTypes.object,
   currentScenariosLayers: PropTypes.array,
   yearIndex: PropTypes.number,
   setYearIndex: PropTypes.func,

--- a/src/pages/distribution/index.js
+++ b/src/pages/distribution/index.js
@@ -7,6 +7,7 @@ import { useQueryParams, setQueryParams } from 'url.js';
 import { COUNTRIES_DEFAULT_VIEWPORTS } from 'constants.js';
 import speciesDistributionLayer from 'layers/speciesDistribution';
 import currentDistributionLayer from 'layers/currentDistribution';
+import speciesOccurenceLayer from 'layers/speciesOccurence';
 
 import Component from './component';
 
@@ -122,9 +123,14 @@ const DistributionPage = props => {
   }, [iso, speciesName, activeFutureScenario, selectedYear, opacity]);
 
   const currentDistLayers = useMemo(() => {
-    const currentDistLayer = currentDistributionLayer(iso, speciesName, opacity);
-    return [currentDistLayer].map(l => ({ ...l, active: true }));
-  }, [iso, speciesName, opacity]);
+    let selectedLayer;
+    if (activeCurrentScenario === 'observed') {
+      selectedLayer = speciesOccurenceLayer(iso, speciesName, 1);
+    } else {
+      selectedLayer = currentDistributionLayer(iso, speciesName, opacity);
+    }
+    return [selectedLayer].map(l => ({ ...l, active: true }));
+  }, [iso, speciesName, opacity, activeCurrentScenario]);
 
   return (
     <Component

--- a/src/pages/distribution/index.js
+++ b/src/pages/distribution/index.js
@@ -24,7 +24,7 @@ const DistributionPage = props => {
   const history = useHistory();
   const currentQueryParams = useQueryParams();
 
-  const { futureScenario } = currentQueryParams;
+  const { futureScenario, currentScenario } = currentQueryParams;
   const { data } = useScenariosPerCountry(iso);
 
   const scenarios = data && data.scenarios;
@@ -33,9 +33,13 @@ const DistributionPage = props => {
 
   const activeFutureScenario =
     futureScenarios && futureScenarios.length ? futureScenario || futureScenarios[0].key : '';
-
   const setFutureScenario = sc => {
     setQueryParams({ ...currentQueryParams, futureScenario: sc }, location, history);
+  };
+
+  const activeCurrentScenario = currentScenario || 'modeled';
+  const setCurrentScenario = sc => {
+    setQueryParams({ ...currentQueryParams, currentScenario: sc }, location, history);
   };
 
   const getYears = sc => {
@@ -57,6 +61,21 @@ const DistributionPage = props => {
       }, {})
     );
   }, [futureScenarios]);
+
+  const currentScenariosData = {
+    observed: {
+      name: 'observed',
+      start: 0,
+      end: 0,
+      step: 1
+    },
+    modeled: {
+      name: 'modeled',
+      start: 0,
+      end: 0,
+      step: 1
+    }
+  };
 
   const futureScenariosData =
     futureScenarios &&
@@ -115,7 +134,10 @@ const DistributionPage = props => {
       setFutureScenario={setFutureScenario}
       futureScenariosData={futureScenariosData}
       futureScenariosLayers={futureDistLayers}
+      currentScenariosData={currentScenariosData}
       currentScenariosLayers={currentDistLayers}
+      activeCurrentScenario={activeCurrentScenario}
+      setCurrentScenario={setCurrentScenario}
       yearIndex={yearIndex}
       setYearIndex={setYearIndex}
       setOpacity={setOpacity}


### PR DESCRIPTION
This PR adds `OBSERVED` layer to the Current Distribution map:
[PIVOTAL](https://www.pivotaltracker.com/story/show/169863163) | [PREVIEW](https://copernicus-forest-git-feature-observed-features.vizzuality1.now.sh/SWE/distribution/ck209expivk2h0b49emszrfls?currentScenario=observed)
![2mi6f-swndr](https://user-images.githubusercontent.com/15097138/69742872-6134a380-1135-11ea-8898-044be88b8c9e.gif)

I didn't implement the clustering feature here, but I'm going to leave it for the next iteration.