### PR TITLE
turn on `no-console` rule as an error

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,12 +9,7 @@
   "rules": {
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": "warn",
-    "no-console": [
-      1,
-      {
-        "allow": ["warn", "error"]
-      }
-    ],
+    "no-console": 2,
     "no-underscore-dangle": 0,
     "class-methods-use-this": 0,
     "no-plusplus": 0,


### PR DESCRIPTION
This tiny PR turns on `no-console` rule as an error in eslint. It's related to [this comment](https://github.com/Vizzuality/copernicus-forest/pull/24#discussion_r352082725).
[More about three error levels](https://eslint.org/docs/user-guide/getting-started#configuration)