### PR TITLE
Fixed graphQL query to get full list of species

### DIFF
--- a/src/graphql/queries.js
+++ b/src/graphql/queries.js
@@ -8,7 +8,7 @@ const useBuildBaseQuery = query => {
 export const useSpeciesPerCountry = iso => {
   return useBuildBaseQuery(`{
     species(where: {
-      countrySpecieDistributions_every: {
+      countrySpecieDistributions_some: {
         country: { iso: "${iso}" }
       }
     }) {

--- a/src/pages/distribution/index.js
+++ b/src/pages/distribution/index.js
@@ -109,7 +109,7 @@ const DistributionPage = props => {
     futureScenariosData && activeFutureScenario && futureScenariosData[activeFutureScenario].years;
 
   const selectedYear = useMemo(() => years && years[yearIndex], [years, yearIndex]);
-  const speciesName = useMemo(() => activeSpecies && activeSpecies.name, [activeSpecies]);
+  const speciesName = useMemo(() => activeSpecies && activeSpecies.scientificName, [activeSpecies]);
 
   const futureDistLayers = useMemo(() => {
     const futureDistLayer = speciesDistributionLayer(


### PR DESCRIPTION
Really minor fix: because of the `_every`, we were getting unique results (where country iso equals `$iso` and only `$iso`) and therefore not getting species that were present in two or more countries.