### PR TITLE
Fix/redirect

### DIFF
--- a/src/AppRouter.jsx
+++ b/src/AppRouter.jsx
@@ -32,7 +32,7 @@ function AppRouter() {
               />
               <Route path="/:iso/species/:id?" component={SpeciesDistributionComponent} />
               <Route path="/:iso/distribution/:id?" component={SpeciesDistributionComponent} />
-              <Route path="/:iso/bioclimatic(/:id?)" component={BioclimaticPage} />
+              <Route path="/:iso/bioclimatic/:id?" component={BioclimaticPage} />
             </Switch>
           </Suspense>
         </div>

--- a/src/AppRouter.jsx
+++ b/src/AppRouter.jsx
@@ -24,9 +24,12 @@ function AppRouter() {
             <Header />
             <Switch>
               <Route path="/" exact component={HomePage} />
-              <Route exact path="/:iso">
-                <Redirect to="/:iso/distribution/:id?" />
-              </Route>
+              <Redirect
+                from="/:iso"
+                exact
+                to="/:iso/distribution/:id?"
+                component={SpeciesDistributionComponent}
+              />
               <Route path="/:iso/species/:id?" component={SpeciesDistributionComponent} />
               <Route path="/:iso/distribution/:id?" component={SpeciesDistributionComponent} />
               <Route path="/:iso/bioclimatic(/:id?)" component={BioclimaticPage} />

--- a/src/AppRouter.jsx
+++ b/src/AppRouter.jsx
@@ -1,6 +1,6 @@
 import React, { lazy, Suspense } from 'react';
 import { Provider, createClient } from 'urql';
-import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
+import { BrowserRouter as Router, Route, Switch, Redirect } from 'react-router-dom';
 import Icons from 'components/icons';
 import './App.scss';
 
@@ -24,9 +24,12 @@ function AppRouter() {
             <Header />
             <Switch>
               <Route path="/" exact component={HomePage} />
+              <Route exact path="/:iso">
+                <Redirect to="/:iso/distribution/:id?" />
+              </Route>
               <Route path="/:iso/species/:id?" component={SpeciesDistributionComponent} />
               <Route path="/:iso/distribution/:id?" component={SpeciesDistributionComponent} />
-              <Route path="/:iso/bioclimatic/:id?" component={BioclimaticPage} />
+              <Route path="/:iso/bioclimatic(/:id?)" component={BioclimaticPage} />
             </Switch>
           </Suspense>
         </div>

--- a/src/components/chart/component.jsx
+++ b/src/components/chart/component.jsx
@@ -58,7 +58,7 @@ const CustomTooltip = props => {
 
 CustomTooltip.propTypes = {
   payload: PropTypes.array,
-  label: PropTypes.string,
+  label: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   metadata: PropTypes.object
 };
 

--- a/src/components/countries-dropdown/component.jsx
+++ b/src/components/countries-dropdown/component.jsx
@@ -42,7 +42,7 @@ function CountriesDropdown() {
         className={cx(styles.countryButton, { [styles.countryButtonActive]: countrySelectorOpen })}
         onClick={toggleCountryDropdown}
       >
-        <span className={styles.title}>{activeCountry.name}</span>
+        <span className={styles.title}>{activeCountry ? activeCountry.name : null}</span>
         <Icon name="icon-dropdown" className={styles.expandIcon} />
       </button>
       {countrySelectorOpen && (

--- a/src/components/header/index.js
+++ b/src/components/header/index.js
@@ -12,9 +12,9 @@ const Header = () => {
   const isSpeciesDistribution = ['species', 'distribution'].includes(type);
 
   const urls = {
-    species: type === 'species' ? '#' : `/${country}/species/`,
-    distribution: type === 'distribution' ? '#' : `/${country}/distribution/`,
-    bioclimatic: type === 'bioclimatic' ? '#' : `/${country}/bioclimatic/`
+    species: type === 'species' ? '#' : `/${country}/species`,
+    distribution: type === 'distribution' ? '#' : `/${country}/distribution`,
+    bioclimatic: type === 'bioclimatic' ? '#' : `/${country}/bioclimatic`
   };
 
   return (

--- a/src/components/menu/component.jsx
+++ b/src/components/menu/component.jsx
@@ -34,14 +34,12 @@ function Menu({ closeMenu, active }) {
     {
       name: 'Species distribution data',
       key: 'species',
-      path: '/SWE/distribution/',
       content: `Species distribution models combine information on species occurrence with environmental characteristics to estimate
         the suitable distributional area under current and future conditions using bioclimatic variables derived from Copernicus data.`
     },
     {
       name: 'Bioclimatic variables data',
       key: 'bioclimatic',
-      path: '/SWE/bioclimatic/',
       content: `Bioclimatic variables derived from Copernicus describing temperature and precipitation annual tendencies, seasonality
         and extreme climatic conditions, including a combination of both environmental factors for current and future scenarios.`
     }

--- a/src/pages/home/component.jsx
+++ b/src/pages/home/component.jsx
@@ -47,7 +47,7 @@ function HomePage() {
                   <div className={styles.row}>
                     {COUNTRIES.map(country => (
                       <div key={country.name} style={{ gridArea: country.name }}>
-                        <Link className={styles.imageLink} to={`/${country.iso}/distribution/`}>
+                        <Link className={styles.imageLink} to={`/${country.iso}/distribution`}>
                           <img
                             className={styles['shape__no-hover']}
                             src={country.svg}

--- a/src/pages/home/components/countries/component.jsx
+++ b/src/pages/home/components/countries/component.jsx
@@ -10,7 +10,7 @@ function ChooseCountry() {
         <div className={styles.row}>
           {COUNTRIES.map(country => (
             <div key={country.name} style={{ gridArea: country.name }}>
-              <Link className={styles.imageLink} to={`/${country.iso}/distribution/`}>
+              <Link className={styles.imageLink} to={`/${country.iso}/distribution`}>
                 <img className={styles['shape__no-hover']} src={country.svg} alt={country.name} />
                 <img className={styles.shape__hover} src={country.svgActive} alt={country.name} />
               </Link>

--- a/src/pages/species-distribution/index.js
+++ b/src/pages/species-distribution/index.js
@@ -22,7 +22,7 @@ const SpeciesDistribution = () => {
 
   useEffect(() => {
     if (species && species.length && !id) {
-      history.push(`${pathname}${species[0].id}`);
+      history.push(`${pathname}/${species[0].id}`);
     }
   }, [history, id, pathname, species]);
 
@@ -38,14 +38,14 @@ const SpeciesDistribution = () => {
     {
       name: 'Species summary',
       path: urls.species,
-      active: pathname.includes('/species/'),
+      active: pathname.includes('/species'),
       page: 'species',
       component: Species
     },
     {
       name: 'Map distribution',
       path: urls.distribution,
-      active: pathname.includes('/distribution/'),
+      active: pathname.includes('/distribution'),
       page: 'distribution',
       component: Distribution
     }


### PR DESCRIPTION
This PR fixes issue "Species distribution default values not working from url".
> Navigate to `/SWE/distribution`:
> - expected: the first species distribution should appear
> - result: blank page appears.

I also added `url/ISO` to go to `/ISO/distribution` page.