### PR TITLE
Removed repeated item

### DIFF
--- a/src/pages/species-distribution/component.jsx
+++ b/src/pages/species-distribution/component.jsx
@@ -39,7 +39,7 @@ const SpeciesDistributionComponent = props => {
         />
         {activeSpecies && (
           <SpeciesList
-            species={species}
+            species={species.filter(s => s.id !== activeSpecies.id)}
             country={activeCountry}
             activeSpecies={activeSpecies}
             page={activePage}


### PR DESCRIPTION
One line fix for [this issue](https://www.pivotaltracker.com/story/show/169867368).

1. The behaviour until the species is selected is the same (hover effect).
2. Then when the species is selected, it is shown only at the top, therefore it's removed from the list.

![image](https://user-images.githubusercontent.com/7013170/70162028-517d0800-16bd-11ea-9353-243450179461.png)
