### PR TITLE
Upgrade Layer Manager to version 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "graphql": "^14.5.8",
     "husky": "^3.0.5",
     "isomorphic-fetch": "^2.2.1",
-    "layer-manager": "^2.0.1",
+    "layer-manager": "^3.0.4",
     "lint-staged": "^9.2.5",
     "lodash": "^4.17.15",
     "luma.gl": "^7.2.0",

--- a/src/constants.js
+++ b/src/constants.js
@@ -145,3 +145,9 @@ export const HEADER_MENU_SECOND = [
     fullUrl: 'http://cds.climate.copernicus.eu/'
   }
 ];
+
+export const DISTRIBUTIONS = {
+  CURRENT: 'current',
+  OBSERVED: 'observed',
+  MODELED: 'modeled'
+};

--- a/src/layers/bioclimatic.js
+++ b/src/layers/bioclimatic.js
@@ -1,18 +1,21 @@
 // vector carto layer for bioclimatic variables data
-export default (iso, scenario, biovar, year, opacity = 1, buckets, rampColors) => {
+export default ({ iso, scenario, biovar, year, opacity = 1, buckets, rampColors }) => {
   return {
-    id: `${iso}${scenario}${biovar}`,
-    type: 'vector',
+    id: `layer-bioclimatic`,
     name: 'Bioclimatic layer',
+    type: 'vector',
+    active: true,
+
     sqlParams: {
       where: {
         iso3: iso
       },
       where2: {
-        scenario,
-        biovar
+        biovar,
+        scenario
       }
     },
+
     source: {
       type: 'vector',
       provider: {
@@ -28,6 +31,7 @@ export default (iso, scenario, biovar, year, opacity = 1, buckets, rampColors) =
         ]
       }
     },
+
     render: {
       maxzoom: 3,
       minzoom: 2,
@@ -52,31 +56,6 @@ export default (iso, scenario, biovar, year, opacity = 1, buckets, rampColors) =
           type: 'fill'
         }
       ]
-    },
-    params_config: [],
-    sql_config: [
-      {
-        key: 'where',
-        key_params: [
-          {
-            key: 'iso3',
-            required: true
-          }
-        ]
-      },
-      {
-        key: 'where2',
-        key_params: [
-          {
-            key: 'scenario',
-            required: true
-          },
-          {
-            key: 'biovar',
-            required: true
-          }
-        ]
-      }
-    ]
+    }
   };
 };

--- a/src/layers/bioclimatic.js
+++ b/src/layers/bioclimatic.js
@@ -2,6 +2,7 @@
 export default (iso, scenario, biovar, year, opacity = 1, buckets, rampColors) => {
   return {
     id: `${iso}${scenario}${biovar}`,
+    type: 'vector',
     name: 'Bioclimatic layer',
     sqlParams: {
       where: {
@@ -12,9 +13,11 @@ export default (iso, scenario, biovar, year, opacity = 1, buckets, rampColors) =
         biovar
       }
     },
-    layerConfig: {
-      account: 'simbiotica',
-      body: {
+    source: {
+      type: 'vector',
+      provider: {
+        type: 'carto',
+        account: 'simbiotica',
         layers: [
           {
             options: {
@@ -22,57 +25,58 @@ export default (iso, scenario, biovar, year, opacity = 1, buckets, rampColors) =
             },
             type: 'cartodb'
           }
-        ],
-        maxzoom: 3,
-        minzoom: 2,
-        vectorLayers: [
-          {
-            filter: ['==', 'year', year],
-            paint: {
-              'fill-color': [
-                'interpolate',
-                ['linear'],
-                ['get', 'wieghtedmean'],
-                buckets[0],
-                rampColors[0],
-                buckets[1],
-                rampColors[1],
-                buckets[2],
-                rampColors[2]
-              ],
-              'fill-opacity': opacity
-            },
-            'source-layer': 'layer0',
-            type: 'fill'
-          }
         ]
-      },
-      params_config: [],
-      sql_config: [
+      }
+    },
+    render: {
+      maxzoom: 3,
+      minzoom: 2,
+      layers: [
         {
-          key: 'where',
-          key_params: [
-            {
-              key: 'iso3',
-              required: true
-            }
-          ]
-        },
-        {
-          key: 'where2',
-          key_params: [
-            {
-              key: 'scenario',
-              required: true
-            },
-            {
-              key: 'biovar',
-              required: true
-            }
-          ]
+          filter: ['==', 'year', year],
+          paint: {
+            'fill-color': [
+              'interpolate',
+              ['linear'],
+              ['get', 'wieghtedmean'],
+              buckets[0],
+              rampColors[0],
+              buckets[1],
+              rampColors[1],
+              buckets[2],
+              rampColors[2]
+            ],
+            'fill-opacity': opacity
+          },
+          'source-layer': 'layer0',
+          type: 'fill'
         }
       ]
     },
-    provider: 'cartodb'
+    params_config: [],
+    sql_config: [
+      {
+        key: 'where',
+        key_params: [
+          {
+            key: 'iso3',
+            required: true
+          }
+        ]
+      },
+      {
+        key: 'where2',
+        key_params: [
+          {
+            key: 'scenario',
+            required: true
+          },
+          {
+            key: 'biovar',
+            required: true
+          }
+        ]
+      }
+    ]
   };
 };

--- a/src/layers/currentDistribution.js
+++ b/src/layers/currentDistribution.js
@@ -1,81 +1,67 @@
 import { SPECIES_RAMP_COLORS } from 'constants.js';
 
 // vector carto layer for species distribution data, scenario "current"
-export default (iso, species, opacity) => {
-  const SCENARIO = 'current';
+export default ({ iso, species, opacity, isVisible = true }) => {
+  const visibility = isVisible ? 'visible' : 'none';
   return {
-    id: `${iso}${species}${SCENARIO}`,
-    name: 'Current distribution carto layer',
+    id: `layer-current-distribution`,
+    name: 'modeled',
+    type: 'vector',
+    active: true,
+
     sqlParams: {
       where: {
         iso3: iso
       },
       where2: {
-        species
+        scenario: 'current',
+        timeinterval: 1995
       }
     },
-    layerConfig: {
-      account: 'simbiotica',
-      body: {
+
+    source: {
+      type: 'vector',
+      provider: {
+        type: 'carto',
+        account: 'simbiotica',
         layers: [
           {
             options: {
-              sql: `WITH a AS (SELECT cartodb_id, the_geom_webmercator, uuid, iso3 FROM all_geometry {{where}}) SELECT a.the_geom_webmercator, a.cartodb_id, b.uuid, b.timeinterval, b.species, b.scenario, b.probabilityemca FROM ${iso.toLowerCase()}_zonal_spp_uuid as b INNER JOIN a ON b.uuid = a.uuid {{where2}}`
+              sql: `WITH a AS (SELECT cartodb_id, the_geom_webmercator, uuid, iso3 FROM all_geometry {{where}}) SELECT a.the_geom_webmercator, a.cartodb_id, b.uuid, b.timeinterval, b.species as species, b.scenario, b.probabilityemca FROM ${iso.toLowerCase()}_zonal_spp_uuid as b INNER JOIN a ON b.uuid = a.uuid {{where2}}`
             },
             type: 'cartodb'
           }
-        ],
-        maxzoom: 3,
-        minzoom: 2,
-        vectorLayers: [
-          {
-            filter: ['==', 'timeinterval', 1995],
-            paint: {
-              'fill-color': [
-                'interpolate',
-                ['linear'],
-                ['get', 'probabilityemca'],
-                0,
-                SPECIES_RAMP_COLORS[0],
-                0.5,
-                SPECIES_RAMP_COLORS[1],
-                1,
-                SPECIES_RAMP_COLORS[2]
-              ],
-              'fill-opacity': opacity
-            },
-            'source-layer': 'layer0',
-            type: 'fill'
-          }
         ]
-      },
-      params_config: [],
-      sql_config: [
+      }
+    },
+
+    render: {
+      maxzoom: 3,
+      minzoom: 2,
+      layers: [
         {
-          key: 'where',
-          key_params: [
-            {
-              key: 'iso3',
-              required: true
-            }
-          ]
-        },
-        {
-          key: 'where2',
-          key_params: [
-            {
-              key: 'species',
-              required: true
-            },
-            {
-              key: 'scenario',
-              required: true,
-              default: SCENARIO
-            }
-          ]
+          filter: ['==', 'species', species],
+          paint: {
+            'fill-color': [
+              'interpolate',
+              ['linear'],
+              ['get', 'probabilityemca'],
+              0,
+              SPECIES_RAMP_COLORS[0],
+              0.5,
+              SPECIES_RAMP_COLORS[1],
+              1,
+              SPECIES_RAMP_COLORS[2]
+            ],
+            'fill-opacity': opacity
+          },
+          layout: {
+            visibility
+          },
+          'source-layer': 'layer0',
+          type: 'fill'
         }
       ]
-    },
-    provider: 'cartodb'
+    }
   };
 };

--- a/src/layers/currentDistribution.js
+++ b/src/layers/currentDistribution.js
@@ -1,11 +1,11 @@
-import { SPECIES_RAMP_COLORS } from 'constants.js';
+import { SPECIES_RAMP_COLORS, DISTRIBUTIONS } from 'constants.js';
 
 // vector carto layer for species distribution data, scenario "current"
 export default ({ iso, species, opacity, isVisible = true }) => {
   const visibility = isVisible ? 'visible' : 'none';
   return {
     id: `layer-current-distribution`,
-    name: 'modeled',
+    name: DISTRIBUTIONS.MODELED,
     type: 'vector',
     active: true,
 
@@ -14,7 +14,7 @@ export default ({ iso, species, opacity, isVisible = true }) => {
         iso3: iso
       },
       where2: {
-        scenario: 'current',
+        scenario: DISTRIBUTIONS.CURRENT,
         timeinterval: 1995
       }
     },

--- a/src/layers/speciesDistribution.js
+++ b/src/layers/speciesDistribution.js
@@ -1,80 +1,62 @@
 import { SPECIES_RAMP_COLORS } from 'constants.js';
 
 // vector carto layer for species distribution data
-export default (iso, species, scenario, year, opacity) => {
+export default ({ iso, species, scenario, year, opacity }) => {
   return {
-    id: `${iso}${species}${scenario}${year}`,
+    id: `layer-species-distribution`,
     name: 'Species distribution carto layer',
+    type: 'vector',
+    active: true,
+
     sqlParams: {
       where: {
         iso3: iso
       },
       where2: {
-        species,
-        scenario
+        species
       }
     },
-    layerConfig: {
-      account: 'simbiotica',
-      body: {
+
+    source: {
+      type: 'vector',
+      provider: {
+        type: 'carto',
+        account: 'simbiotica',
         layers: [
           {
             options: {
-              sql: `WITH a AS (SELECT cartodb_id, the_geom_webmercator, uuid, iso3 FROM all_geometry {{where}}) SELECT a.the_geom_webmercator, a.cartodb_id, b.uuid, b.timeinterval as year, b.species, b.scenario, b.probabilityemca FROM ${iso.toLowerCase()}_zonal_spp_uuid as b INNER JOIN a ON b.uuid = a.uuid {{where2}}`
+              sql: `WITH a AS (SELECT cartodb_id, the_geom_webmercator, uuid, iso3 FROM all_geometry {{where}}) SELECT a.the_geom_webmercator, a.cartodb_id, b.uuid, b.timeinterval as year, b.species as species, b.scenario as scenario, b.probabilityemca FROM ${iso.toLowerCase()}_zonal_spp_uuid as b INNER JOIN a ON b.uuid = a.uuid {{where2}}`
             },
             type: 'cartodb'
           }
-        ],
-        maxzoom: 3,
-        minzoom: 2,
-        vectorLayers: [
-          {
-            filter: ['==', 'year', year],
-            paint: {
-              'fill-color': [
-                'interpolate',
-                ['linear'],
-                ['get', 'probabilityemca'],
-                0,
-                SPECIES_RAMP_COLORS[0],
-                0.5,
-                SPECIES_RAMP_COLORS[1],
-                1,
-                SPECIES_RAMP_COLORS[2]
-              ],
-              'fill-opacity': opacity
-            },
-            'source-layer': 'layer0',
-            type: 'fill'
-          }
         ]
-      },
-      params_config: [],
-      sql_config: [
+      }
+    },
+
+    render: {
+      maxzoom: 3,
+      minzoom: 2,
+      layers: [
         {
-          key: 'where',
-          key_params: [
-            {
-              key: 'iso3',
-              required: true
-            }
-          ]
-        },
-        {
-          key: 'where2',
-          key_params: [
-            {
-              key: 'species',
-              required: true
-            },
-            {
-              key: 'scenario',
-              required: true
-            }
-          ]
+          filter: ['all', ['==', 'year', year], ['==', 'scenario', scenario]],
+          paint: {
+            'fill-color': [
+              'interpolate',
+              ['linear'],
+              ['get', 'probabilityemca'],
+              0,
+              SPECIES_RAMP_COLORS[0],
+              0.5,
+              SPECIES_RAMP_COLORS[1],
+              1,
+              SPECIES_RAMP_COLORS[2]
+            ],
+            'fill-opacity': opacity
+          },
+          'source-layer': 'layer0',
+          type: 'fill'
         }
       ]
-    },
-    provider: 'cartodb'
+    }
   };
 };

--- a/src/layers/speciesOccurence.js
+++ b/src/layers/speciesOccurence.js
@@ -1,4 +1,4 @@
-import { SPECIES_RAMP_COLORS } from 'constants.js';
+import { SPECIES_RAMP_COLORS, DISTRIBUTIONS } from 'constants.js';
 
 // vector carto layer for species occurence data
 export default ({ iso, species, opacity = 1, isVisible = true }) => {
@@ -6,7 +6,7 @@ export default ({ iso, species, opacity = 1, isVisible = true }) => {
 
   return {
     id: `layer-species-occurence`,
-    name: 'observed',
+    name: DISTRIBUTIONS.OBSERVED,
     type: 'vector',
     active: true,
 

--- a/src/layers/speciesOccurence.js
+++ b/src/layers/speciesOccurence.js
@@ -1,19 +1,26 @@
 import { SPECIES_RAMP_COLORS } from 'constants.js';
 
 // vector carto layer for species occurence data
-export default (iso, species, opacity = 1) => {
+export default ({ iso, species, opacity = 1, isVisible = true }) => {
+  const visibility = isVisible ? 'visible' : 'none';
+
   return {
-    id: `${iso}${species}`,
-    name: 'Species occurence carto layer',
+    id: `layer-species-occurence`,
+    name: 'observed',
+    type: 'vector',
+    active: true,
+
     sqlParams: {
       where: {
-        iso3: iso,
-        species
+        iso3: iso
       }
     },
-    layerConfig: {
-      account: 'simbiotica',
-      body: {
+
+    source: {
+      type: 'vector',
+      provider: {
+        type: 'carto',
+        account: 'simbiotica',
         layers: [
           {
             options: {
@@ -21,40 +28,33 @@ export default (iso, species, opacity = 1) => {
             },
             type: 'cartodb'
           }
-        ],
-        maxzoom: 3,
-        minzoom: 2,
-        vectorLayers: [
-          {
-            paint: {
-              'circle-color': SPECIES_RAMP_COLORS[2],
-              'circle-opacity': opacity,
-              'circle-radius': {
-                stops: [[12, 2], [22, 180]]
-              }
-            },
-            'source-layer': 'layer0',
-            type: 'circle'
-          }
         ]
-      },
-      params_config: [],
-      sql_config: [
+      }
+    },
+
+    render: {
+      maxzoom: 3,
+      minzoom: 2,
+      layers: [
         {
-          key: 'where',
-          key_params: [
-            {
-              key: 'iso3',
-              required: true
-            },
-            {
-              key: 'species',
-              required: true
+          filter: ['==', 'species', species],
+          paint: {
+            'circle-color': SPECIES_RAMP_COLORS[2],
+            'circle-opacity': opacity,
+            'circle-radius': {
+              stops: [
+                [12, 2],
+                [22, 180]
+              ]
             }
-          ]
+          },
+          layout: {
+            visibility
+          },
+          'source-layer': 'layer0',
+          type: 'circle'
         }
       ]
-    },
-    provider: 'cartodb'
+    }
   };
 };

--- a/src/pages/bioclimatic/component.jsx
+++ b/src/pages/bioclimatic/component.jsx
@@ -13,7 +13,7 @@ import RampLegend from 'components/ramp-legend';
 import bioclimaticLayer from 'layers/bioclimatic';
 import { LayerManager, Layer } from 'layer-manager/dist/components';
 import { PluginMapboxGl } from 'layer-manager';
-import { TEMPERATURE_RAMP_COLORS, PERCIPITATION_RAMP_COLORS } from 'constants.js';
+import { TEMPERATURE_RAMP_COLORS, PERCIPITATION_RAMP_COLORS, DISTRIBUTIONS } from 'constants.js';
 import cx from 'classnames';
 
 import { getBuckets } from './utils';
@@ -91,7 +91,7 @@ function BioClimaticPage(props) {
               title: `BIO ${i + 1} = ${bv.name}`,
               id: bv.key,
               data: sortBy(biovarsData[bv.key], 'name').map(d =>
-                d.name === 1995 ? { ...d, name: 'current' } : d
+                d.name === 1995 ? { ...d, name: DISTRIBUTIONS.CURRENT } : d
               ),
               config: getConfig(bv.unit),
               metadata: {

--- a/src/pages/bioclimatic/component.jsx
+++ b/src/pages/bioclimatic/component.jsx
@@ -54,16 +54,16 @@ function BioClimaticPage(props) {
   const buckets = fetching ? [] : getBuckets(biovarsData[chosenBiovar]);
   const bioclimaticLayers = useMemo(() => {
     if (fetching) return [];
-    const layer = bioclimaticLayer(
-      country,
+    const layer = bioclimaticLayer({
+      iso: country,
       scenario,
-      chosenBiovar,
-      years[yearIndex],
+      biovar: chosenBiovar,
+      year: years[yearIndex],
       opacity,
       buckets,
       rampColors
-    );
-    return [layer].map(l => ({ ...l, active: true }));
+    });
+    return [layer];
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [biovarsData, chosenBiovar, country, scenario, years, yearIndex, fetching, opacity]);
 

--- a/src/pages/bioclimatic/index.js
+++ b/src/pages/bioclimatic/index.js
@@ -1,7 +1,7 @@
 import React, { useMemo, useEffect, useState } from 'react';
 import { useRouteMatch, useLocation, useHistory } from 'react-router-dom';
 import { useQueryParams, setQueryParams } from 'url.js';
-import { COUNTRIES_DEFAULT_VIEWPORTS, DEFAULT_LAYER_OPACITY } from 'constants.js';
+import { COUNTRIES_DEFAULT_VIEWPORTS, DEFAULT_LAYER_OPACITY, DISTRIBUTIONS } from 'constants.js';
 import { useScenariosPerCountry } from 'graphql/queries';
 import { Query } from 'urql';
 import { Label } from 'recharts';
@@ -40,7 +40,8 @@ const Container = () => {
   useEffect(() => setViewport(COUNTRIES_DEFAULT_VIEWPORTS[country]), [country]);
 
   // parsing
-  const scenarios = data && data.scenarios && data.scenarios.filter(s => s.key !== 'current');
+  const scenarios =
+    data && data.scenarios && data.scenarios.filter(s => s.key !== DISTRIBUTIONS.CURRENT);
   const parsedScenarios =
     scenarios &&
     sortBy(

--- a/src/pages/distribution/index.js
+++ b/src/pages/distribution/index.js
@@ -4,7 +4,7 @@ import { useLocation, useHistory } from 'react-router-dom';
 import { uniqBy, sortBy } from 'lodash';
 import { useScenariosPerCountry } from 'graphql/queries';
 import { useQueryParams, setQueryParams } from 'url.js';
-import { COUNTRIES_DEFAULT_VIEWPORTS, DEFAULT_LAYER_OPACITY } from 'constants.js';
+import { COUNTRIES_DEFAULT_VIEWPORTS, DEFAULT_LAYER_OPACITY, DISTRIBUTIONS } from 'constants.js';
 import speciesDistributionLayer from 'layers/speciesDistribution';
 import currentDistributionLayer from 'layers/currentDistribution';
 import speciesOccurenceLayer from 'layers/speciesOccurence';
@@ -33,7 +33,7 @@ const DistributionPage = props => {
   const futureScenarios =
     scenarios &&
     sortBy(
-      scenarios.filter(({ key }) => key !== 'current'),
+      scenarios.filter(({ key }) => key !== DISTRIBUTIONS.CURRENT),
       'key'
     );
 
@@ -43,7 +43,7 @@ const DistributionPage = props => {
     setQueryParams({ ...currentQueryParams, futureScenario: sc }, location, history);
   };
 
-  const activeCurrentScenario = currentScenario || 'modeled';
+  const activeCurrentScenario = currentScenario || DISTRIBUTIONS.MODELED;
   const setCurrentScenario = sc => {
     setQueryParams({ ...currentQueryParams, currentScenario: sc }, location, history);
   };
@@ -74,13 +74,13 @@ const DistributionPage = props => {
 
   const currentScenariosData = {
     observed: {
-      name: 'observed',
+      name: DISTRIBUTIONS.OBSERVED,
       start: 0,
       end: 0,
       step: 1
     },
     modeled: {
-      name: 'modeled',
+      name: DISTRIBUTIONS.MODELED,
       start: 0,
       end: 0,
       step: 1
@@ -138,12 +138,12 @@ const DistributionPage = props => {
     };
     const _speciesOccurenceLayer = speciesOccurenceLayer({
       ...sharedParams,
-      isVisible: activeCurrentScenario === 'observed'
+      isVisible: activeCurrentScenario === DISTRIBUTIONS.OBSERVED
     });
     const _currentDistLayer = currentDistributionLayer({
       ...sharedParams,
       opacity: layerOpacity,
-      isVisible: activeCurrentScenario === 'modeled'
+      isVisible: activeCurrentScenario === DISTRIBUTIONS.MODELED
     });
     return [_speciesOccurenceLayer, _currentDistLayer];
   }, [iso, speciesName, layerOpacity, activeCurrentScenario]);

--- a/src/pages/distribution/index.js
+++ b/src/pages/distribution/index.js
@@ -31,7 +31,11 @@ const DistributionPage = props => {
 
   const scenarios = data && data.scenarios;
   const futureScenarios =
-    scenarios && sortBy(scenarios.filter(({ key }) => key !== 'current'), 'key');
+    scenarios &&
+    sortBy(
+      scenarios.filter(({ key }) => key !== 'current'),
+      'key'
+    );
 
   const activeFutureScenario =
     futureScenarios && futureScenarios.length ? futureScenario || futureScenarios[0].key : '';
@@ -117,24 +121,31 @@ const DistributionPage = props => {
   const speciesName = useMemo(() => activeSpecies && activeSpecies.scientificName, [activeSpecies]);
 
   const futureDistLayers = useMemo(() => {
-    const futureDistLayer = speciesDistributionLayer(
+    const futureDistLayer = speciesDistributionLayer({
       iso,
-      speciesName,
-      activeFutureScenario,
-      selectedYear,
-      layerOpacity
-    );
-    return [futureDistLayer].map(l => ({ ...l, active: true }));
+      species: speciesName,
+      scenario: activeFutureScenario,
+      year: selectedYear,
+      opacity: layerOpacity
+    });
+    return [futureDistLayer];
   }, [iso, speciesName, activeFutureScenario, selectedYear, layerOpacity]);
 
   const currentDistLayers = useMemo(() => {
-    let selectedLayer;
-    if (activeCurrentScenario === 'observed') {
-      selectedLayer = speciesOccurenceLayer(iso, speciesName, 1);
-    } else {
-      selectedLayer = currentDistributionLayer(iso, speciesName, layerOpacity);
-    }
-    return [selectedLayer].map(l => ({ ...l, active: true }));
+    const sharedParams = {
+      iso,
+      species: speciesName
+    };
+    const _speciesOccurenceLayer = speciesOccurenceLayer({
+      ...sharedParams,
+      isVisible: activeCurrentScenario === 'observed'
+    });
+    const _currentDistLayer = currentDistributionLayer({
+      ...sharedParams,
+      opacity: layerOpacity,
+      isVisible: activeCurrentScenario === 'modeled'
+    });
+    return [_speciesOccurenceLayer, _currentDistLayer];
   }, [iso, speciesName, layerOpacity, activeCurrentScenario]);
 
   return (

--- a/yarn.lock
+++ b/yarn.lock
@@ -7444,10 +7444,10 @@ layer-manager@^1.10.0:
     supercluster "^4.1.1"
     wri-json-api-serializer "^1.0.1"
 
-layer-manager@^2.0.1:
-  version "2.0.9"
-  resolved "https://registry.yarnpkg.com/layer-manager/-/layer-manager-2.0.9.tgz#a7ef5def99b2a7137e0e6586b0764357016d6c6d"
-  integrity sha512-mrjFwKNDeXm3Ccgb6LTqt/zpd8OdDacDMvIJm3QCNhE9TXMV/wxx8I7cy8HVX1oRriZipZiXKuOO3d3erJQXbg==
+layer-manager@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/layer-manager/-/layer-manager-3.0.4.tgz#c066f41de79cfb6b75b390d85fef1042437d37c1"
+  integrity sha512-z7agDGDUkdpwaGMV0KcHg7duAtHP4qoZmryszNKQlcz0lBNeqXiarrzLhYLzv+n3wuZQVrzpZ/TQXN1gWmG6Tw==
   dependencies:
     axios "^0.19.0"
     lodash "^4.17.15"


### PR DESCRIPTION
This PR upgrades the version of the `layer-manager` package to the latest one `3.0.4`. In order to do that I had to change the shape of the layer config objects and replace the `layerConfig` with new `source` and `render` properties.  [(More about the update to version 3 in the documentation)](https://github.com/Vizzuality/layer-manager#migration-to-layer-manager-3x)
New version enables a smooth transition  between years on the map, so while the timeline is playing, the "blinking" effect doesn't occur anymore  :

**Layer Manager v2:**
![fnhse-y9mjh](https://user-images.githubusercontent.com/15097138/82061298-d20e4e80-96c8-11ea-9573-b55e992f74f8.gif)

**Layer Manager v3:**
![pqchj-lcuw8](https://user-images.githubusercontent.com/15097138/82061572-2e716e00-96c9-11ea-949a-b702565d3a33.gif)

_Before start run **`yarn install`** to update your version of the layer-manager_
**Test:**
Check layers, maps, and the transition effect on both pages, Species distribution, and Bioclimatic Variables.